### PR TITLE
Add example HTML and CSS for Webfonts

### DIFF
--- a/iA Writer Duospace/Webfonts/fonts.css
+++ b/iA Writer Duospace/Webfonts/fonts.css
@@ -1,0 +1,35 @@
+@font-face {
+  font-family: "iA Writer Duospace";
+  font-weight: normal;
+  font-style: normal;
+  src: url("iAWriterDuospace-Regular.eot") format("embedded-opentype"),
+    url("iAWriterDuospace-Regular.woff2") format("woff2"),
+    url("iAWriterDuospace-Regular.woff") format("woff");
+}
+
+@font-face {
+  font-family: "iA Writer Duospace";
+  font-weight: normal;
+  font-style: italic;
+  src: url("iAWriterDuospace-RegularItalic.eot") format("embedded-opentype"),
+    url("iAWriterDuospace-RegularItalic.woff2") format("woff2"),
+    url("iAWriterDuospace-RegularItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: "iA Writer Duospace";
+  font-weight: bold;
+  font-style: normal;
+  src: url("iAWriterDuospace-Bold.eot") format("embedded-opentype"),
+    url("iAWriterDuospace-Bold.woff2") format("woff2"),
+    url("iAWriterDuospace-Bold.woff") format("woff");
+}
+
+@font-face {
+  font-family: "iA Writer Duospace";
+  font-weight: bold;
+  font-style: italic;
+  src: url("iAWriterDuospace-BoldItalic.eot") format("embedded-opentype"),
+    url("iAWriterDuospace-BoldItalic.woff2") format("woff2"),
+    url("iAWriterDuospace-BoldItalic.woff") format("woff");
+}

--- a/iA Writer Duospace/Webfonts/index.html
+++ b/iA Writer Duospace/Webfonts/index.html
@@ -1,0 +1,51 @@
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>iA Writer Duospace</title>
+    <link rel="stylesheet" href="fonts.css">
+    <style>
+        body {
+            font-family: 'iA Writer Duospace', monospace;
+            font-size: 16px;
+            line-height: 1.5;
+        }
+
+        #root {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        .regular {
+            font-weight: normal;
+        }
+
+        .bold {
+            font-weight: bold;
+        }
+
+        .normal {
+            font-style: normal;
+        }
+
+        .italic {
+            font-style: italic;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="root">
+        <h1>iA Writer Duospace for Web</h1>
+        <p>
+            Hell just froze over. After seven years of offering no font options to write, iA Writer now comes with a choice. Next to
+            the monospace Nitti you’ll find a brand new duospace font.
+        </p>
+        <p class="regular normal">Regular normal</p>
+        <p class="regular italic">Regular italic</p>
+        <p class="bold normal">Bold normal</p>
+        <p class="bold italic">Bold italic</p>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Here’s a re-usable CSS file and an example HTML file to illustrate web font usage and help with testing. Works in latest Safari, Firefox and Chrome. Should work in IE. Might close #15, but it might also be a good idea to add a few specimen next to illustrate the duo space nature of the font!

Thanks again for providing the web font version @iaolo, I’ve always been dying to use Nitti on the web, but this is even better and free!