### PR TITLE
Fix Path in fonts.css to Italic Webfont Files

### DIFF
--- a/iA Writer Duospace/Webfonts/fonts.css
+++ b/iA Writer Duospace/Webfonts/fonts.css
@@ -11,9 +11,9 @@
   font-family: "iA Writer Duospace";
   font-weight: normal;
   font-style: italic;
-  src: url("iAWriterDuospace-RegularItalic.eot") format("embedded-opentype"),
-    url("iAWriterDuospace-RegularItalic.woff2") format("woff2"),
-    url("iAWriterDuospace-RegularItalic.woff") format("woff");
+  src: url("iAWriterDuospace-Italic.eot") format("embedded-opentype"),
+    url("iAWriterDuospace-Italic.woff2") format("woff2"),
+    url("iAWriterDuospace-Italic.woff") format("woff");
 }
 
 @font-face {


### PR DESCRIPTION
Thanks for making those fonts available on GitHub 🙇‍♂️. As I was looking at the `webfonts`, I noticed there was a typo in the regular italic font file names which would cause anyone using this as an example to host/integrate on their blog/site to get an error loading the italic variant of `iA Writer Duospace`. 
